### PR TITLE
Enable Linux & Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8)
 project (Cube)
 
 file(GLOB SRC "src/*.cpp")
@@ -9,14 +9,21 @@ include_directories(include)
 include_directories(src)
 include_directories(/usr/local/include)
 
-target_link_libraries(Cube
-# -lstdc++ \
-  "-framework Cocoa"
-  "-framework CoreVideo"
-  "-framework IOKit"
-  "-framework OpenGL"
-  "-framework Glut"
-)
+if(APPLE)
+    target_link_libraries(Cube
+        "-framework Cocoa"
+        "-framework CoreVideo"
+        "-framework IOKit"
+        "-framework OpenGL"
+        "-framework GLUT"
+    )
+else()
+    find_package(OpenGL REQUIRED)
+    find_package(GLUT REQUIRED)
+    find_package(GLEW REQUIRED)
+    include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS} ${GLEW_INCLUDE_DIRS})
+    target_link_libraries(Cube ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES} ${GLEW_LIBRARIES})
+endif()
 
 configure_file(shaders/vshader.glsl vshader.glsl COPYONLY)
 configure_file(shaders/fshader.glsl fshader.glsl COPYONLY)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ OpenGL Rubiks Cube
 
 ## Building
 
-To build on Mac, run
+### macOS
+
+Run the following:
 
 ```
 mkdir build && cd build
@@ -15,3 +17,30 @@ make
 ```
 
 Then run `./Cube` from the `build` folder
+
+### Linux
+
+Install the development packages for OpenGL, GLUT (or FreeGLUT) and GLEW
+(package names vary per distribution). Then run:
+
+```
+mkdir build && cd build
+cmake ..
+make
+```
+
+Run `./Cube` from the `build` folder.
+
+### Windows
+
+Use a terminal such as the Visual Studio Developer Command Prompt and ensure
+that the OpenGL, GLUT and GLEW development libraries are installed and visible
+to CMake. Then run:
+
+```
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+The resulting executable `Cube.exe` will be placed in the `build` directory.


### PR DESCRIPTION
## Summary
- update CMakeLists.txt to link to OpenGL/GLUT/GLEW on non-macOS systems
- document build instructions for macOS, Linux and Windows

## Testing
- `git status --short`